### PR TITLE
cleanup event handlers and expose props more consistently

### DIFF
--- a/src/child-button.js
+++ b/src/child-button.js
@@ -9,7 +9,7 @@ var ChildButton = React.createClass({
       <li>
         <a href={this.props.href}
            data-mfb-label={this.props.label}
-           onClick={this.props.onClick && this.props.onClick.bind(this)}
+           onClick={this.props.onClick}
            className="mfb-component__button--child">
           <i className={iconClass}></i>
         </a>

--- a/src/main-button.js
+++ b/src/main-button.js
@@ -3,22 +3,28 @@
 var React = require('react');
 
 var MainButton = React.createClass({
-  handleClick: function() {
-    this.props.onToggleMenu();
+  getDefaultProps: function(){
+    return {
+      href: '#',
+      onClick: function(){},
+      iconResting: '',
+      iconActive: '',
+      label: null
+    };
   },
   render: function(){
     var iconResting = 'mfb-component__main-icon--resting ' + this.props.iconResting,
         iconActive = 'mfb-component__main-icon--active ' + this.props.iconActive;
     if(this.props.label){
       return (
-        <a href={this.props.href} className="mfb-component__button--main" onClick={this.handleClick} data-mfb-label={this.props.label}>
+        <a href={this.props.href} className="mfb-component__button--main" onClick={this.props.onClick} data-mfb-label={this.props.label}>
           <i className={iconResting}></i>
           <i className={iconActive}></i>
         </a>
       );
     } else {
       return (
-        <a href="#" className="mfb-component__button--main" onClick={this.handleClick}>
+        <a href={this.props.href} className="mfb-component__button--main" onClick={this.props.onClick}>
           <i className={iconResting}></i>
           <i className={iconActive}></i>
         </a>

--- a/src/menu.js
+++ b/src/menu.js
@@ -20,7 +20,9 @@ var Menu = React.createClass({
     };
   },
 
-  toggleMenu: function() {
+  toggleMenu: function(evt) {
+    evt.preventDefault();
+
     if(this.props.method === 'hover'){
       return;
     }
@@ -35,7 +37,7 @@ var Menu = React.createClass({
     var buttons = getChildren(this.props.children);
 
     var main = buttons.main && React.cloneElement(buttons.main, {
-      onToggleMenu: this.toggleMenu
+      onClick: this.toggleMenu
     });
 
     return (


### PR DESCRIPTION
I've done some generic cleanup.  I found that using MainButton standalone is a pretty smooth experience, so I've rename `onToggleMenu` to just `onClick`.  I also noticed some warnings when using with React 0.13