### PR TITLE
Icon support for other libraries

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -20,7 +20,7 @@ var effect = 'zoomin',
 function renderMenu(){
   var component = (
     <Menu effect={effect} method={method} position={pos}>
-      <MainButton iconResting="ion-plus-round" iconActive="ion-close-round" />
+      <MainButton iconRestingClass="ion-plus-round" iconActiveClass="ion-close-round" />
       <ChildButton
         //onClick={function(e){ console.log(e); e.preventDefault(); }}
         icon="ion-social-github"

--- a/src/main-button.js
+++ b/src/main-button.js
@@ -10,25 +10,27 @@ var MainButton = React.createClass({
       onClick: function(){},
       iconResting: '',
       iconActive: '',
-      label: null
+      label: null,
+      iconRestingClass: '',
+      iconActiveClass: ''
     };
   },
   render: function(){
-    var iconResting = classnames('mfb-component__main-icon--resting', this.props.iconResting);
-    var iconActive = classnames('mfb-component__main-icon--active', this.props.iconActive);
+    var iconRestingClass = classnames('mfb-component__main-icon--resting', this.props.iconRestingClass);
+    var iconActiveClass = classnames('mfb-component__main-icon--active', this.props.iconActiveClass);
     var mainClass = classnames('mfb-component__button--main', this.props.className);
     if(this.props.label){
       return (
         <a href={this.props.href} className={mainClass} onClick={this.props.onClick} data-mfb-label={this.props.label}>
-          <i className={iconResting}></i>
-          <i className={iconActive}></i>
+          <i className={iconRestingClass}>{this.props.iconResting}</i>
+          <i className={iconActiveClass}>{this.props.iconActive}</i>
         </a>
       );
     } else {
       return (
         <a href={this.props.href} className={mainClass} onClick={this.props.onClick}>
-          <i className={iconResting}></i>
-          <i className={iconActive}></i>
+          <i className={iconRestingClass}>{this.props.iconResting}</i>
+          <i className={iconActiveClass}>{this.props.iconActive}</i>
         </a>
       );
     }


### PR DESCRIPTION
Other icon libraries, such as material-icons, may use innerHTML of <i> to place the icon instead of a className.