### PR TITLE
Remove PropTypes deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "classnames": "^1.2.0",
+    "prop-types": "^15.5.10",
     "react-dom": "^15.3.1"
   },
   "peerDependencies": {

--- a/src/menu.js
+++ b/src/menu.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var React = require('react');
+var PropTypes = require("prop-types");
 
 var getClasses = require('./utils/get-classes');
 var getChildren = require('./utils/get-children');
@@ -9,8 +10,8 @@ var childrenValidator = require('./utils/children-validator');
 var Menu = React.createClass({
 
   propTypes: {
-    effect: React.PropTypes.oneOf(['zoomin', 'slidein', 'slidein-spring', 'fountain']).isRequired,
-    position: React.PropTypes.oneOf(['tl', 'tr', 'bl', 'br']).isRequired,
+    effect: PropTypes.oneOf(['zoomin', 'slidein', 'slidein-spring', 'fountain']).isRequired,
+    position: PropTypes.oneOf(['tl', 'tr', 'bl', 'br']).isRequired,
     children: childrenValidator
   },
 


### PR DESCRIPTION
This PR aims to fix this warning message:

```Warning: Accessing PropTypes via the main React package is deprecated. Use the prop-types package from npm instead.```