### PR TITLE
Include missing scss files in npm distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+_
 node_modules
 bower_components
 .sass-cache/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,14 +3,14 @@
 var gulp = require('gulp');
 var babel = require('gulp-babel');
 
-gulp.task('js', function(){
+gulp.task('js', function () {
   return gulp.src('./src/**/*.js')
     .pipe(babel())
     .pipe(gulp.dest('build'));
 });
 
-gulp.task('css', function(){
-  return gulp.src(['./mfb/src/mfb.css', './mfb/src/mfb.css.map', './mfb/src/mfb.scss'])
+gulp.task('css', function () {
+  return gulp.src(['**/mfb.css', '**/mfb.css.map', '**/*.scss'], { base: './mfb/src/' })
     .pipe(gulp.dest('./'));
 });
 


### PR DESCRIPTION
`mfb.scss` file includes scss files from `mfb/src/_`, but
those file were not included in `package.json`'s `files` section.

resolves #31