### PR TITLE
update peer dependencies for react 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "react-dom": "^15.3.1"
   },
   "peerDependencies": {
-    "react": "^15.3.1"
+    "react": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
     "browserify": "^9.0.3",


### PR DESCRIPTION
Resolves warning:

`npm WARN react-mfb@0.6.0 requires a peer of react@^15.3.1 but none is installed. You must install peer dependencies yourself.`